### PR TITLE
Add Brazilian Portuguese translation + misc. translation changes

### DIFF
--- a/translations/pt/ssh.phrases.txt
+++ b/translations/pt/ssh.phrases.txt
@@ -1,0 +1,427 @@
+"Phrases"
+{
+	//Punishment menu title
+	//{Name} ({SteamID}). Last Logo sprayed {#Seconds}s ago.
+	"Title"
+	{
+		"pt"			"{1} ({2}). Último spray colocado há {3}s."
+	}
+
+	//Admin spray menu title
+	"Admin Spray Menu"
+	{
+		"pt"			"Selecione um jogador"
+	}
+
+	//Punishment option
+	"Warn"
+	{
+		"pt"			"Avisar jogador"
+	}
+
+	//Punishment option
+	"SlapWarn"
+	{
+		"pt"			"Estapear ({1} de dano) e avisar jogador"
+	}
+
+	//Punishment option
+	"Slay"
+	{
+		"pt"			"Assassinar jogador"
+	}
+
+	//Punishment option
+	//Burn Player for {#of Seconds} seconds
+	"BurnWarn"
+	{
+		"pt"			"Queimar jogador por {1}s"
+	}
+
+	//Punishment option
+	"Freeze"
+	{
+		"pt"			"Congelar"
+	}
+
+	//Punishment option
+	"Beacon"
+	{
+		"pt"			"Sinalizador"
+	}
+
+	//Punishment option
+	"FreezeBomb"
+	{
+		"pt"			"Bomba de congelamento"
+	}
+
+	//Punishment option
+	"FireBomb"
+	{
+		"pt"			"Bomba incendiária"
+	}
+
+	//Punishment option
+	"TimeBomb"
+	{
+		"pt"			"Bomba-relógio"
+	}
+
+	//Punishment option
+	"Drug"
+	{
+		"pt"			"Drogar"
+	}
+
+	//Punishment option
+	"Kick"
+	{
+		"pt"			"Expulsar jogador"
+	}
+
+	//Punishment option
+	//Ban Player for {#Minutes} minute(s)
+	"Ban"
+	{
+		"pt"			"Banir jogador"
+	}
+
+	//Punishment option
+	"PBan"
+	{
+		"pt"			"Banir jogador permanentemente"
+	}
+	
+	//Punishment option
+	"SPBan"
+	{
+		"pt"			"Banir jogador de usar sprays"
+	}
+
+	//Menu option
+	"Trace"
+	{
+		"pt"			"Rastrear spray"
+	}
+
+	//Menu option
+	"Remove"
+	{
+		"pt"			"Remover spray"
+	}
+	
+	//Menu option
+	"QuickRemove"
+	{
+		"pt"			"Remover spray rapidamente"
+	}
+
+	//Menu option
+	"AdminSpray"
+	{
+		"pt"			"Spray de administrador"
+	}
+
+	//Warning
+	"Please change"
+	{
+		"pt"			"Altere o seu spray; ele é inapropriado."
+	}
+
+	//Kick reason
+	"Bad Spray Logo"
+	{
+		"pt"			"Spray inapropriado"
+	}
+
+	//Command reply
+	"Could Not Find"
+	{
+		"pt"			"Alvo não encontrado"
+	}
+
+	//Punishment reply
+	//Could not find player {Name} ({SteamID})
+	"Could Not Find Name ID"
+	{
+		"pt"			"Jogador {1} ({2}) não encontrado"
+	}
+
+	//Punishment reply
+	//Could not find player {Name}
+	"Could Not Find Name"
+	{
+		"pt"			"Jogador {1} não encontrado"
+	}
+
+	//Punishment annoucement
+	//Warned player {Name} ({SteamID})
+	"Warned"
+	{
+		"pt"			"Aviso enviado para {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Slapped and warned player {Name} ({SteamID}) for {#Damage} dmg
+	"Slapped And Warned"
+	{
+		"pt"			"Estapeou ({3} de dano) e avisou {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Slayed and warned player {Name} ({SteamID})
+	"Slayed And Warned"
+	{
+		"pt"			"Assassinou e avisou {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Burnt and warned player {Name} ({SteamID})
+	"Burnt And Warned"
+	{
+		"pt"			"Incendiou e avisou {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Froze player {Name} ({SteamID})
+	"Froze"
+	{
+		"pt"			"Congelou {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Put a beacon on player {Name} ({SteamID})
+	"Beaconed"
+	{
+		"pt"			"Pôs um sinalizador em {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Put a freeze bomb on player {Name} ({SteamID})
+	"FreezeBombed"
+	{
+		"pt"			"Pôs uma bomba de congelamento em {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Put a fire bomb on player {Name} ({SteamID})
+	"FireBombed"
+	{
+		"pt"			"Pôs uma bomba incendiária em {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Put a time bomb on player {Name} ({SteamID})
+	"TimeBombed"
+	{
+		"pt"			"Pôs uma bomba-relógio em {1} ({2})"
+	}
+
+	//Punishment message
+	//Drugged player {1} ({2})
+	"Drugged"
+	{
+		"pt"			"Drogou {1} ({2})"
+	}
+
+	//Punishment annoucement
+	//Kicked player {Name} ({SteamID}) for a bad spray logo
+	"Kicked"
+	{
+		"pt"			"Expulsou {1} ({2}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//"{AdminName} banned player {Name} ({SteamID}) for {#Minutes} minutes for a bad spray logo"
+	"Banned"
+	{
+		"pt"			"{1} baniu {2} ({3}) por {4} minutos devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//"{AdminName} banned player {Name} ({SteamID}) for {#Minutes} minutes with {External Ban Name} for a bad spray logo"
+	"EBanned"
+	{
+		"pt"			"{1} baniu {2} ({3}) por {4} minutos com {5} devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//"{AdminName} permanently banned player {Name} ({SteamID}) for a bad spray logo"
+	"PBanned"
+	{
+		"pt"			"{1} baniu {2} ({3}) permanentemente devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//"{AdminName} permanently banned player {Name} ({SteamID}) with {External Ban Name} for a bad spray logo"
+	"EPBanned"
+	{
+		"pt"			"{1} baniu {2} ({3}) permanentemente com {4} devido ao uso de um spray inapropriado"
+	}
+	
+	//Punishment annoucement
+	//"{AdminName} Spray banned player {Name} ({SteamID}) for a bad spray logo"
+	"SPBanned"
+	{
+		"pt"	"{1} aplicou um banimento de spray em {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Command reply
+	//Sprayed by: {Name} ({SteamID})
+	"Sprayed"
+	{
+		"pt"			"Colocado por: {1} ({2})"
+	}
+
+	//Command reply
+	//Sprayed by: {Name}
+	"Sprayed Name"
+	{
+		"pt"			"Colocado por: {1} ({2})"
+	}
+
+	//Command reply
+	//{AdminName} sprayed {Target}'s spray
+	"Admin Sprayed"
+	{
+		"pt"			"{1} colocou o spray de {2}"
+	}
+
+	//Command Reply
+	"Cannot Spray"
+	{
+		"pt"			"Erro: não é possível colocar o spray do alvo"
+	}
+
+	//Command reply
+	//Spray by {Name} ({SteamID}), {#Seconds}s ago.
+	"Spray By"
+	{
+		"pt"			"Colocado por {1} ({2}) há {3}s"
+	}
+
+	//Command reply
+	"No Spray"
+	{
+		"pt"			"Nenhum spray foi encontrado sob a sua mira"
+	}
+	
+	//Command reply
+	"No Sprays"
+	{
+		"pt"			"Nenhum spray foi colocado."
+	}
+
+	//Command reply
+	//Spray from {Name} ({SteamID}) has been removed by {AdminName}
+	"Spray Removed"
+	{
+		"pt"			"O spray de {1} ({2}) foi removido por {3}"
+	}
+	
+	//Command reply
+	//All Sprays have been removed by {AdminName}.
+	"Sprays Removed"
+	{
+		"pt"			"Todos os sprays foram removidos por {1}"
+	}
+
+	//Punishment logging
+	//{AdminName} warned player {Name} ({SteamID})
+	"Log Warned"
+	{
+		"pt"			"{1} avisou {1} ({2})"
+	}
+
+	//Punishment logging
+	//{AdminName} slapped and warned player {Name} ({SteamID})
+	"Log Slapped And Warned"
+	{
+		"pt"			"{1} estapeou ({4} de dano) e avisou {2} ({3})"
+	}
+
+	//Punishment logging
+	//{AdminName} slayed and warned player {Name} ({SteamID})
+	"Log Slayed And Warned"
+	{
+		"pt"			"{1} assassinou e avisou {2} ({3})"
+	}
+
+	//Punishment logging
+	//{AdminName} burnt and warned player {Name} ({SteamID})
+	"Log Burnt And Warned"
+	{
+		"pt"			"{1} incendiou e avisou {2} ({3})"
+	}
+
+	//Punishment annoucement
+	//{AdminName} froze player {Name} ({SteamID}) for a bad spray logo
+	"Log Froze"
+	{
+		"pt"			"{1} congelou {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//{AdminName} put a beacon on player {Name} ({SteamID}) for a bad spray logo
+	"Log Beaconed"
+	{
+		"pt"			"{1} pôs um sinalizador {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//{AdminName} put a freeze bomb on player {Name} ({SteamID}) for a bad spray logo
+	"Log FreezeBombed"
+	{
+		"pt"			"{1} pôs uma bomba de congelamento {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//{AdminName} put a fire bomb on player {Name} ({SteamID}) for a bad spray logo
+	"Log FireBombed"
+	{
+		"pt"			"{1} pôs um bomba incendiária {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment annoucement
+	//{AdminName} put a time bomb on player {Name} ({SteamID}) for a bad spray logo
+	"Log TimeBombed"
+	{
+		"pt"			"{1} pôs uma bomba-relógio {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment message
+	//{AdminName} drugged player {Name} ({SteamID}) for a bad spray logo
+	"Log Drugged"
+	{
+		"pt"			"{1} drogou {2} ({3}) devido ao uso de um spray inapropriado"
+	}
+
+	//Punishment logging
+	//{AdminName} kicked player {Name} ({SteamID}) for a bad spray logo
+	"Log Kicked"
+	{
+		"pt"			"{1} expulsou {2} devido ao uso de um spray inapropriado"
+	}
+	
+	//Punishment logging
+	//{AdminName} Spray Banned {Name} ({SteamID}) for a bad spray logo
+	"Log SPBanned"
+	{
+		"pt"			"{1} baniu {2} ({3}) de usar sprays devido ao uso de um spray inapropriado."
+	}
+
+	//Command fail reply
+	//{AdminName} tried to punish {OtherAdminName} but failed. {OtherAdminName} has higher immunity.
+	"Admin Immune Log"
+	{
+		"pt"			"{1} tentou punir {2}, mas não consegiu. {2} tem uma imunidade maior."
+	}
+
+	//Command fail reply
+	//You tried to punish {OtherAdminName} but failed. {OtherAdminName} has higher immunity.
+	"Admin Immune"
+	{
+		"pt"			"Você tentou punir {1}, mas não conseguiu. {1} tem uma imunidade maior."
+	}
+}

--- a/translations/ru/ssh.phrases.txt
+++ b/translations/ru/ssh.phrases.txt
@@ -4,7 +4,6 @@
 	//{Name} ({SteamID}). Last Logo sprayed {#Seconds}s ago.
 	"Title"
 	{
-		"#format"		"{1:s},{2:s},{3:d}"
 		"ru"			"{1} ({2}). Последний логотип нанесён {3}с назад."
 	}
 
@@ -23,7 +22,6 @@
 	//Punishment option
 	"SlapWarn"
 	{
-		"#format"		"{1:d}"
 		"ru"			"Шлёпнул и предупредил игрока на {1} урона"
 	}
 
@@ -37,7 +35,6 @@
 	//Burn Player for {#of Seconds} seconds
 	"BurnWarn"
 	{
-		"#format"		"{1:d}"
 		"ru"			"Поджег игрока на {1} секунд"
 	}
 
@@ -148,7 +145,6 @@
 	//Could not find player {Name} ({SteamID})
 	"Could Not Find Name ID"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Не удалось найти игрока {1} ({2})"
 	}
 
@@ -156,7 +152,6 @@
 	//Could not find player {Name}
 	"Could Not Find Name"
 	{
-		"#format"		"{1:s}"
 		"ru"			"Не удалось найти игрока {1}"
 	}
 
@@ -164,7 +159,6 @@
 	//Warned player {Name} ({SteamID})
 	"Warned"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Предупредил игрока {1} ({2})"
 	}
 
@@ -172,7 +166,6 @@
 	//Slapped and warned player {Name} ({SteamID}) for {#Damage} dmg
 	"Slapped And Warned"
 	{
-		"#format"		"{1:s},{2:s},{3:d}"
 		"ru"			"Шлёпнул и предупредил игрока {1} ({2}) на {3} урона"
 	}
 
@@ -180,7 +173,6 @@
 	//Slayed and warned player {Name} ({SteamID})
 	"Slayed And Warned"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Убил и предупредил игрока {1} ({2})"
 	}
 
@@ -188,7 +180,6 @@
 	//Burnt and warned player {Name} ({SteamID})
 	"Burnt And Warned"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Поджег и предупредил игрока {1} ({2})"
 	}
 
@@ -196,7 +187,6 @@
 	//Froze player {Name} ({SteamID})
 	"Froze"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Заморозил игрока {1} ({2})"
 	}
 
@@ -204,7 +194,6 @@
 	//Put a beacon on player {Name} ({SteamID})
 	"Beaconed"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Установил маяк на игрока {1} ({2})"
 	}
 
@@ -212,7 +201,6 @@
 	//Put a freeze bomb on player {Name} ({SteamID})
 	"FreezeBombed"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Установил замораживающую бомбу на игрока {1} ({2})"
 	}
 
@@ -220,7 +208,6 @@
 	//Put a fire bomb on player {Name} ({SteamID})
 	"FireBombed"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Установил огненную бомбу на игрока {1} ({2})"
 	}
 
@@ -228,7 +215,6 @@
 	//Put a time bomb on player {Name} ({SteamID})
 	"TimeBombed"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Установил бомбу с таймером на игрока {1} ({2})"
 	}
 
@@ -236,7 +222,6 @@
 	//Drugged player {1} ({2})
 	"Drugged"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Опьянил игрока {1} ({2})"
 	}
 
@@ -244,7 +229,6 @@
 	//Kicked player {Name} ({SteamID}) for a bad spray logo
 	"Kicked"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Выгнал игрока {1} ({2}) за плохой спрей"
 	}
 
@@ -252,7 +236,6 @@
 	//"{AdminName} banned player {Name} ({SteamID}) for {#Minutes} minutes for a bad spray logo"
 	"Banned"
 	{
-		"#format"		"{1:s},{2:s},{3:s},{4:d}"
 		"ru"			"{1} забанил игрока {2} ({3}) на {4} минут за плохой спрей"
 	}
 
@@ -260,7 +243,6 @@
 	//"{AdminName} banned player {Name} ({SteamID}) for {#Minutes} minutes with {External Ban Name} for a bad spray logo"
 	"EBanned"
 	{
-		"#format"		"{1:s},{2:s},{3:s},{4:d},{5:s}"
 		"ru"			"{1} забанил игрока {2} ({3}) на {4} минут с причиной {5} за плохой спрей"
 	}
 
@@ -268,7 +250,6 @@
 	//"{AdminName} permanently banned player {Name} ({SteamID}) for a bad spray logo"
 	"PBanned"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} навсегда забанил игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -276,7 +257,6 @@
 	//"{AdminName} permanently banned player {Name} ({SteamID}) for a bad spray logo with {External Ban Name}"
 	"EPBanned"
 	{
-		"#format"		"{1:s},{2:s},{3:s},{4:s}"
 		"ru"			"{1} навсегда забанил игрока {2} ({3}) за плохой спрей с причиной {4}"
 	}
 	
@@ -284,7 +264,6 @@
 	//"{AdminName} Spray banned player {Name} ({SteamID}) for a bad spray logo"
 	"SPBanned"
 	{
-		"#format"	"{1:s},{2:s},{3:s}"
 		"ru"	"{1} Забанил спрей игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -292,7 +271,6 @@
 	//Sprayed by: {Name} ({SteamID})
 	"Sprayed"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"Спрей игрока: {1} ({2})"
 	}
 
@@ -300,7 +278,6 @@
 	//Sprayed by: {Name}
 	"Sprayed Name"
 	{
-		"#format"		"{1:s}"
 		"ru"			"Спрей игрока: {1}"
 	}
 
@@ -308,7 +285,6 @@
 	//{AdminName} sprayed {Target}'s spray
 	"Admin Sprayed"
 	{
-		"#format"		"{1:N},{2:N}"
 		"ru"			"{1} нанёс спрей игрока {2}"
 	}
 
@@ -322,7 +298,6 @@
 	//Spray by {Name} ({SteamID}), {#Seconds}s ago.
 	"Spray By"
 	{
-		"#format"		"{1:s},{2:s},{3:d}"
 		"ru"			"Спрей игрока {1} ({2}), {3} секунд назад"
 	}
 
@@ -342,7 +317,6 @@
 	//Spray from {Name} ({SteamID}) has been removed by {AdminName}
 	"Spray Removed"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"Спрей игрока {1} ({2}) был удален игроком {3}"
 	}
 	
@@ -350,7 +324,6 @@
 	//All Sprays have been removed by {AdminName}.
 	"Sprays Removed"
 	{
-		"#format"		"{1:s}"
 		"ru"			"Все спреи были удалены игроком {1}"
 	}
 
@@ -358,7 +331,6 @@
 	//{AdminName} warned player {Name} ({SteamID})
 	"Log Warned"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} предупредил игрока {2} ({3})"
 	}
 
@@ -366,7 +338,6 @@
 	//{AdminName} slapped and warned player {Name} ({SteamID})
 	"Log Slapped And Warned"
 	{
-		"#format"		"{1:s},{2:s},{3:s},{4:d}"
 		"ru"			"{1} шлёпнул и предупредил игрока {2} ({3}) на {4} урона"
 	}
 
@@ -374,7 +345,6 @@
 	//{AdminName} slayed and warned player {Name} ({SteamID})
 	"Log Slayed And Warned"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} убил и предупредил игрока {2} ({3})"
 	}
 
@@ -382,7 +352,6 @@
 	//{AdminName} burnt and warned player {Name} ({SteamID})
 	"Log Burnt And Warned"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} поджег и предупредил игрока {2} ({3})"
 	}
 
@@ -390,7 +359,6 @@
 	//{AdminName} froze player {Name} ({SteamID}) for a bad spray logo
 	"Log Froze"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} заморозил игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -398,7 +366,6 @@
 	//{AdminName} put a beacon on player {Name} ({SteamID}) for a bad spray logo
 	"Log Beaconed"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} установил маяк на игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -406,7 +373,6 @@
 	//{AdminName} put a freeze bomb on player {Name} ({SteamID}) for a bad spray logo
 	"Log FreezeBombed"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} установил замораживающую бомбу на игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -414,7 +380,6 @@
 	//{AdminName} put a fire bomb on player {Name} ({SteamID}) for a bad spray logo
 	"Log FireBombed"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} установил огненную бомбу на игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -422,7 +387,6 @@
 	//{AdminName} put a time bomb on player {Name} ({SteamID}) for a bad spray logo
 	"Log TimeBombed"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} установил бомбу с таймером на игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -430,7 +394,6 @@
 	//{AdminName} drugged player {Name} ({SteamID}) for a bad spray logo
 	"Log Drugged"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} опьянил игрока {2} ({3}) за плохой спрей"
 	}
 
@@ -438,7 +401,6 @@
 	//{AdminName} kicked player {Name} ({SteamID}) for a bad spray logo
 	"Log Kicked"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} выгнал игрока {2} ({3}) за плохой спрей"
 	}
 	
@@ -446,7 +408,6 @@
 	//{AdminName} Spray Banned {Name} ({SteamID}) for a bad spray logo
 	"Log SPBanned"
 	{
-		"#format"		"{1:s},{2:s},{3:s}"
 		"ru"			"{1} Забанил спрей игрока {2} ({3}) за плохой спрей."
 	}
 
@@ -454,7 +415,6 @@
 	//{AdminName} tried to punish {OtherAdminName} but failed. {OtherAdminName} has higher immunity.
 	"Admin Immune Log"
 	{
-		"#format"		"{1:s},{2:s}"
 		"ru"			"{1} пытался наказать {2} но не удалось. {2} имеет высокий иммунитет."
 	}
 
@@ -462,7 +422,6 @@
 	//You tried to punish {OtherAdminName} but failed. {OtherAdminName} has higher immunity.
 	"Admin Immune"
 	{
-		"#format"		"{1:s}"
 		"ru"			"Вы пытались наказать {1} но не удалось. {1} имеет высокий иммунитет."
 	}
 }

--- a/translations/ssh.phrases.txt
+++ b/translations/ssh.phrases.txt
@@ -273,11 +273,11 @@
 	}
 
 	//Punishment annoucement
-	//"{AdminName} permanently banned player {Name} ({SteamID}) for a bad spray logo with {External Ban Name}"
+	//"{AdminName} permanently banned player {Name} ({SteamID}) with {External Ban Name} for a bad spray logo"
 	"EPBanned"
 	{
 		"#format"		"{1:s},{2:s},{3:s},{4:s}"
-		"en"			"{1} permanently banned player {2} ({3}) for a bad spray logo with {4}"
+		"en"			"{1} permanently banned player {2} ({3}) with {4} for a bad spray logo"
 	}
 	
 	//Punishment annoucement


### PR DESCRIPTION
This pull request:

- adds a Brazilian Portuguese translation for the plugin;
- removes all "format" from Russian translations, since they aren't necessary due to the fact that the translations are organized in subfolders;
- fix an inconsistency in the English translation file between two strings that share "{External Ban Name}", but have it in different places in the sentences.

@Blueberryy Considering the possible approval of this author's plugin to this pull request, you can send another one to also fix the third problem in Russian translations (I already fixed it in the Brazilian Portuguese translations).

Thanks in advance.